### PR TITLE
Mysql string

### DIFF
--- a/config/datastores.js
+++ b/config/datastores.js
@@ -48,8 +48,11 @@ module.exports.datastores = {
     *    (See https://sailsjs.com/config/datastores for help.)                 *
     *                                                                          *
     ***************************************************************************/
-    adapter: 'sails-disk',
+    //adapter: 'sails-disk',
     // url: 'mysql://user:password@host:port/database',
+    adapter: require('sails-mysql'),
+    url: 'mysql://root:<password>@172.19.175.250:3306/fleetdm_sails',
+
 
   },
 

--- a/config/datastores.js
+++ b/config/datastores.js
@@ -51,7 +51,8 @@ module.exports.datastores = {
     //adapter: 'sails-disk',
     // url: 'mysql://user:password@host:port/database',
     adapter: require('sails-mysql'),
-    url: 'mysql://root:<password>@172.19.175.250:3306/fleetdm_sails',
+    //url: 'mysql://root:<password>@172.19.175.250:3306/fleetdm_sails',
+    //url/connection string is set via sails_datastores__default__url enviornmet variable
 
 
   },

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -54,7 +54,7 @@ module.exports = {
     //     rejectUnauthorized: false,
     //   }
     adapter: require('sails-mysql'),
-    url: 'mysql://root:<password>@172.19.25.145:3306/fleetdm_sails',
+    url: 'mysql://root:<password>@172.19.175.250:3306/fleetdm_sails',
       //--------------------------------------------------------------------------
       //  /\   To avoid checking it in to version control, you might opt to set
       //  ||   sensitive credentials like `url` using an environment variable.

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -54,7 +54,7 @@ module.exports = {
     //     rejectUnauthorized: false,
     //   }
     adapter: require('sails-mysql'),
-    url: 'mysql://root:<password>@172.19.175.250:3306/fleetdm_sails',
+    //url: 'mysql://root:<password>@172.19.175.250:3306/fleetdm_sails',
       //--------------------------------------------------------------------------
       //  /\   To avoid checking it in to version control, you might opt to set
       //  ||   sensitive credentials like `url` using an environment variable.


### PR DESCRIPTION
* removing mysql string. this allows us to:
* define an env var `sails_datastores__default__url` with the password in it from HCV
* not need to manually overwrite the password template