### PR TITLE
removing uneeded npm packages to reduce docker images and remove pote…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apk update && apk upgrade
 RUN npm install -g npm@9.6.6
 WORKDIR .
 COPY . .
-RUN npm install sails -g
 RUN npm install;  npm run build-for-prod; rm -rf node_modules/
 RUN npm install --omit=dev
 CMD sails lift --prod

--- a/package.json
+++ b/package.json
@@ -5,16 +5,13 @@
   "description": "a Sails application",
   "keywords": [],
   "dependencies": {
-    "@sailshq/connect-redis": "^6.1.3",
     "@sailshq/lodash": "^3.10.3",
-    "@sailshq/socket.io-redis": "^5.2.0",
     "moment-timezone": "0.5.39",
     "sails": "^1.5.4",
     "sails-hook-apianalytics": "^2.0.5",
     "sails-hook-organics": "^2.2.1",
     "sails-hook-orm": "^4.0.2",
     "sails-hook-sockets": "^2.0.1",
-    "sails-postgresql": "^5.0.1",
     "sails-mysql": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
removing packages that are not required in our deployment:
* Redis is only needed to persist session state extended periods of time
* Postgres is not used for our deployment
* Also snuck in removing the sails global install since npm is installing it as a dependency anyways