### PR TITLE
Fixing sails path in dockerfile to use npm installed package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ WORKDIR .
 COPY . .
 RUN npm install;  npm run build-for-prod; rm -rf node_modules/
 RUN npm install --omit=dev
-CMD sails lift --prod
+CMD /node_modules/.bin/sails lift --prod
 EXPOSE 1337


### PR DESCRIPTION
[In a prior PR](https://github.com/fastly/fleetdm-vulnerability-dashboard/pull/7/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L8), I removed the sails global installed package. Thus we need to reference the npm installed package via absolute path.